### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol (MCP) server for Magento 2 development, designed to int
 
 <img width="690" height="705" alt="image" src="https://github.com/user-attachments/assets/491e4f5d-d145-46b7-a509-56982508199a" />
 
+<a href="https://glama.ai/mcp/servers/@elgentos/magento2-dev-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@elgentos/magento2-dev-mcp/badge" alt="Magento 2 Development Server MCP server" />
+</a>
+
 ## Installation
 
 ### Using npx


### PR DESCRIPTION
This PR adds a badge for the [Magento 2 Development MCP Server](https://glama.ai/mcp/servers/@elgentos/magento2-dev-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@elgentos/magento2-dev-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@elgentos/magento2-dev-mcp/badge" alt="Magento 2 Development Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.